### PR TITLE
Ignore md5 processing if folders are found in AV databases

### DIFF
--- a/modules/antivirus/base.py
+++ b/modules/antivirus/base.py
@@ -213,6 +213,9 @@ class Antivirus(object):
     def database(self):
         if not self._database:
             self._database = self.get_database()
+            # NOTE: Expecting to have only files, thus filtering folders
+            if self._database:
+                self._database = filter(os.path.isfile, self._database)
         return self._database
 
     @property


### PR DESCRIPTION
For antivirus databases, if md5 are added by mistake, we simply ignore their
md5 calculation, and they will not be added to the PluginResult neither
