### PR TITLE
1247 - Make antivirus sha256 metadata computation error safe

### DIFF
--- a/modules/antivirus/interface.py
+++ b/modules/antivirus/interface.py
@@ -58,6 +58,9 @@ class AntivirusPluginInterface(object):
         if os.path.exists(filename):
             result['mtime'] = os.path.getmtime(filename)
             result['ctime'] = os.path.getctime(filename)
-            with open(filename, 'rb') as fd:
-                result['sha256'] = hashlib.sha256(fd.read()).hexdigest()
+            try:
+                with open(filename, 'rb') as fd:
+                    result['sha256'] = hashlib.sha256(fd.read()).hexdigest()
+            except Exception as e:
+                result['sha256'] = None
         return result


### PR DESCRIPTION
Due to DAC on Linux, the irma probe application may not be able to read
antivirus database metadata. This fix makes the sha256 calculation for an
antivirus database error safe. If the calculation failed, None is set in the
corresponding field.