### PR TITLE
Open NSRLOS.txt for reading and writing

### DIFF
--- a/modules/database/nsrl/nsrl.py
+++ b/modules/database/nsrl/nsrl.py
@@ -209,7 +209,7 @@ class NSRLLevelDict(LevelDictSerialized, LevelDBSingleton):
         # create database
         db = cls(dbfile, **kwargs)
         # open csv files
-        csv_file = open(records, 'r')
+        csv_file = open(records, 'w+')
         csv_entries = DictReader(csv_file)
 
         for index, row in enumerate(csv_entries):


### PR DESCRIPTION
```
irma@brain:/opt/irma/irma-probe/current$ python -m modules.database.nsrl.nsrl create -t os NSRLOS.txt /home/irma/leveldb/os_db
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/opt/irma/irma-probe/releases/20141124132755/modules/database/nsrl/nsrl.py", line 466, in <module>
    func(**args)
  File "/opt/irma/irma-probe/releases/20141124132755/modules/database/nsrl/nsrl.py", line 367, in nsrl_create_database
    kwargs['filename'])
  File "/opt/irma/irma-probe/releases/20141124132755/modules/database/nsrl/nsrl.py", line 212, in create_database
    csv_file = open(records, 'r')
IOError: [Errno 2] No such file or directory: 'NSRLOS.txt'
```