### PR TITLE
Fixed search path for Sophos

### DIFF
--- a/modules/antivirus/sophos/sophos.py
+++ b/modules/antivirus/sophos/sophos.py
@@ -80,7 +80,9 @@ class Sophos(Antivirus):
         # always installed by default. Instead, hardcode some common paths and
         # locate files using predefined patterns
         if self._is_windows:
-            search_paths = map(lambda x: "{path}/Sophos/*".format(path=x),
+            path = 'Sophos/Sophos Anti-Virus'
+            search_paths = map(lambda x: "{program_files}/{path}/*"
+                                         "".format(program_files=x, path=path),
                                [os.environ.get('PROGRAMFILES', ''),
                                 os.environ.get('PROGRAMFILES(X86)', '')])
         else:
@@ -102,9 +104,10 @@ class Sophos(Antivirus):
     def get_scan_path(self):
         """return the full path of the scan tool"""
         if self._is_windows:
+            path = 'Sophos/Sophos Anti-Virus'
             scan_bin = "sav32cli.exe"
-            scan_paths = map(lambda x:
-                             "{path}/Sophos".format(path=x),
+            scan_paths = map(lambda x: "{program_files}/{path}"
+                                       "".format(program_files=x, path=path),
                              [os.environ.get('PROGRAMFILES', ''),
                               os.environ.get('PROGRAMFILES(X86)', '')])
         else:


### PR DESCRIPTION
Default path was set to "ProgramFiles/Sophos/" instead of
"ProgramFiles/Sophos/Sophos Anti-Virus/"

The latter is the default when using the following installer:
http://downloads.sophos.com/dt/wwwreq/escw_103_sa_sfx.exe