### PR TITLE
Emsisoft Asquared (see commit logs for install details)

### DIFF
--- a/modules/antivirus/emsisoft/asquared.py
+++ b/modules/antivirus/emsisoft/asquared.py
@@ -1,0 +1,85 @@
+#
+# Copyright (c) 2013-2014 QuarksLab.
+# This file is part of IRMA project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the top-level directory
+# of this distribution and at:
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# No part of the project, including this file, may be copied,
+# modified, propagated, or distributed except according to the
+# terms contained in the LICENSE file.
+
+import logging
+import re
+import os
+
+from modules.antivirus.base import Antivirus
+
+log = logging.getLogger(__name__)
+
+
+class ASquaredCmd(Antivirus):
+
+    # ==================================
+    #  Constructor and destructor stuff
+    # ==================================
+
+    def __init__(self, *args, **kwargs):
+        # class super class constructor
+        super(ASquaredCmd, self).__init__(*args, **kwargs)
+        # set default antivirus information
+        self._name = "Emsisoft Commandline Scanner"
+        # scan tool variables
+        self._scan_args = (
+            "/h "
+            "/r "
+            "/a "
+            "/n "
+            "/f "
+        )
+        # scan tool variables
+        self._scan_patterns = [
+            re.compile(r'\\\s+(?P<file>.*)\s+detected:\s+(?P<name>.*[^\s]+)')
+        ]
+
+    # ==========================================
+    #  Antivirus methods (need to be overriden)
+    # ==========================================
+
+    def get_version(self):
+        """return the version of the antivirus"""
+        result = None
+        if self.scan_path:
+            cmd = self.build_cmd(self.scan_path)
+            retcode, stdout, stderr = self.run_cmd(cmd)
+            if not retcode:
+                matches = re.search(r'(?P<version>\d+(\.\d+)+)',
+                                    stdout, re.IGNORECASE)
+                if matches:
+                    result = matches.group('version').strip()
+        return result
+
+    def get_database(self):
+        """return list of files in the database"""
+        # TODO: make locate() to be reccursive, and to extend selected folders
+        pf_path = [os.environ.get('PROGRAMFILES', ''),
+                   os.environ.get('PROGRAMFILES(X86)', '')]
+        search_paths = map(lambda (x, y):
+                           "{path}/Emsisoft/a2cmd/Signatures/{folder}"
+                           "".format(path=x, folder=y),
+                           ((x, y) for x in pf_path for y in ['', 'BD']))
+        results = self.locate('*', search_paths, syspath=False)
+        return results if results else None
+
+    def get_scan_path(self):
+        """return the full path of the scan tool"""
+        scan_bin = "a2cmd.exe"
+        scan_paths = map(lambda x: "{path}/Emsisoft/a2cmd/".format(path=x),
+                         [os.environ.get('PROGRAMFILES', ''),
+                          os.environ.get('PROGRAMFILES(X86)', '')])
+        paths = self.locate(scan_bin, scan_paths)
+        return paths[0] if paths else None

--- a/modules/antivirus/emsisoft/plugin.py
+++ b/modules/antivirus/emsisoft/plugin.py
@@ -1,0 +1,59 @@
+#
+# Copyright (c) 2013-2014 QuarksLab.
+# This file is part of IRMA project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the top-level directory
+# of this distribution and at:
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# No part of the project, including this file, may be copied,
+# modified, propagated, or distributed except according to the
+# terms contained in the LICENSE file.
+
+import os
+
+from .asquared import ASquaredCmd
+from ..interface import AntivirusPluginInterface
+
+from lib.plugins import PluginBase, PluginLoadError
+from lib.plugins import PlatformDependency
+from lib.irma.common.utils import IrmaProbeType
+
+
+class ASquaredCmdPlugin(PluginBase, ASquaredCmd, AntivirusPluginInterface):
+
+    # =================
+    #  plugin metadata
+    # =================
+
+    _plugin_name_ = "ASquaredCmd"
+    _plugin_author_ = "IRMA (c) Quarkslab"
+    _plugin_version_ = "1.0.0"
+    _plugin_category_ = IrmaProbeType.antivirus
+    _plugin_description_ = "Plugin for ASquaredCmd on Windows"
+    _plugin_dependencies_ = [
+        PlatformDependency('win32')
+    ]
+
+    @classmethod
+    def verify(cls):
+        # create an instance
+        module = ASquaredCmd()
+        path = module.scan_path
+        del module
+        # perform checks
+        if not path or not os.path.exists(path):
+            raise PluginLoadError("{0}: verify() failed because "
+                                  "ASquaredCmd executable was not found."
+                                  "".format(cls.__name__))
+
+    # =============
+    #  constructor
+    # =============
+
+    def __init__(self):
+        # load default configuration file
+        self.module = ASquaredCmd()

--- a/tests/antivirus/test_asquared.py
+++ b/tests/antivirus/test_asquared.py
@@ -1,0 +1,62 @@
+import logging
+import unittest
+
+from tests.antivirus.common import GenericEicar
+from modules.antivirus.emsisoft.asquared import ASquaredCmd
+
+
+# ============
+#  Test Cases
+# ============
+
+class ASquaredCmdEicar(GenericEicar, unittest.TestCase):
+
+    expected_results = {
+        'eicar.cab': 'EICAR-Test-File (not a virus) (B)',
+        'eicar.com.txt': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau2.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_lha.bin': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_gz.bin': 'EICAR-Test-File (not a virus) (B)',
+        'eicarhqx_binhex.bin': 'Trojan.Script.135850 (B)',
+        'eicar_mime.bin': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_cab.bin': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau30.rar': None,
+        'eicar_uu.bin': 'EICAR-Test-File (not a virus) (B)',
+        'eicar.plain': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau8.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar.lha': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau14.jpg': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau5.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau4.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau1.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau30.bin': None,
+        'eicar_niveau9.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau7.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar.rar': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau11.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau10.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_tar.bin': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_lzh.bin': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau3.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau13.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau14.bin': 'EICAR-Test-File (not a virus) (B)',
+        'eicar.tar': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau6.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_rar.bin': 'EICAR-Test-File (not a virus) (B)',
+        'eicar.uue': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_niveau12.zip': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_arj.bin': 'EICAR-Test-File (not a virus) (B)',
+        'eicar.lzh': 'EICAR-Test-File (not a virus) (B)',
+        'eicar.com.pgp': None,
+        'eicar-passwd.zip': None,
+        'eicar.arj': 'EICAR-Test-File (not a virus) (B)',
+        'eicar.msc': 'EICAR-Test-File (not a virus) (B)',
+        'eicar_msc.bin': 'EICAR-Test-File (not a virus) (B)',
+    }
+
+    antivirus_class = ASquaredCmd
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- the tested copy of Emsisoft Asquared is available at the following URL:
  http://download1.emsisoft.com/a2cmd.zip
- the default search path is %PROGRAMFILES%/Emsisoft/a2cmd/. The archive must
  be unzipped in this folder
- to trigger an update, run 'a2cmd.exe /update' from the command line