### PR TITLE
Fix copyright and make travis-ci run pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+  - "2.7"
+
+install: 
+  - pip install pep8
+
+before_script:
+  - pep8 --version
+
+script: 
+  - pep8 config extras modules probe tests tools
+
+notifications:
+  email:
+    on_success: never

--- a/config/parser.py
+++ b/config/parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/avast/avast.py
+++ b/modules/antivirus/avast/avast.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/avast/plugin.py
+++ b/modules/antivirus/avast/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/avast/plugin.py
+++ b/modules/antivirus/avast/plugin.py
@@ -37,7 +37,7 @@ class AvastCoreSecurityPlugin(PluginBase, AvastCoreSecurity,
         PlatformDependency('linux'),
         BinaryDependency(
             'scan',
-            help='scan executable is provided by Avast Core Security For Linux.'
+            help='scan executable is provided by Avast Core Security For Linux'
         ),
     ]
 

--- a/modules/antivirus/avg/avg.py
+++ b/modules/antivirus/avg/avg.py
@@ -50,8 +50,11 @@ class AVGAntiVirusFree(Antivirus):
                        r'Virus identified|Trojan horse)\s+'
                        r'(?P<name>.*)(\\n)*.*$', re.IGNORECASE)
         ]
+
+        def is_error_fn(x):
+            return x in [1, 2, 3, 6, 7, 8, 9, 10]
+
         # NOTE: do 'man avgscan' for return codes
-        is_error_fn = lambda x: x in [1, 2, 3, 6, 7, 8, 9, 10]
         self._scan_retcodes[self.ScanResult.CLEAN] = lambda x: x in [0]
         self._scan_retcodes[self.ScanResult.INFECTED] = lambda x: x in [4, 5]
         self._scan_retcodes[self.ScanResult.ERROR] = lambda x: is_error_fn(x)

--- a/modules/antivirus/avg/avg.py
+++ b/modules/antivirus/avg/avg.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/avg/plugin.py
+++ b/modules/antivirus/avg/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/avira/avira.py
+++ b/modules/antivirus/avira/avira.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/avira/plugin.py
+++ b/modules/antivirus/avira/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/base.py
+++ b/modules/antivirus/base.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/bitdefender/bitdefender.py
+++ b/modules/antivirus/bitdefender/bitdefender.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/bitdefender/plugin.py
+++ b/modules/antivirus/bitdefender/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/clamav/clam.py
+++ b/modules/antivirus/clamav/clam.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/clamav/plugin.py
+++ b/modules/antivirus/clamav/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/comodo/cavl.py
+++ b/modules/antivirus/comodo/cavl.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/comodo/plugin.py
+++ b/modules/antivirus/comodo/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/drweb/drweb.py
+++ b/modules/antivirus/drweb/drweb.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/drweb/plugin.py
+++ b/modules/antivirus/drweb/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/emsisoft/asquared.py
+++ b/modules/antivirus/emsisoft/asquared.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/emsisoft/plugin.py
+++ b/modules/antivirus/emsisoft/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/escan/escan.py
+++ b/modules/antivirus/escan/escan.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/escan/plugin.py
+++ b/modules/antivirus/escan/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/eset/nod32.py
+++ b/modules/antivirus/eset/nod32.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/eset/plugin.py
+++ b/modules/antivirus/eset/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/fprot/fprot.py
+++ b/modules/antivirus/fprot/fprot.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/fprot/plugin.py
+++ b/modules/antivirus/fprot/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/fsecure/fsecure.py
+++ b/modules/antivirus/fsecure/fsecure.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/fsecure/plugin.py
+++ b/modules/antivirus/fsecure/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/gdata/gdata.py
+++ b/modules/antivirus/gdata/gdata.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/gdata/plugin.py
+++ b/modules/antivirus/gdata/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/interface.py
+++ b/modules/antivirus/interface.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/kaspersky/kaspersky.py
+++ b/modules/antivirus/kaspersky/kaspersky.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/kaspersky/plugin.py
+++ b/modules/antivirus/kaspersky/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/mcafee/plugin.py
+++ b/modules/antivirus/mcafee/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/mcafee/vscl.py
+++ b/modules/antivirus/mcafee/vscl.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/sophos/plugin.py
+++ b/modules/antivirus/sophos/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/sophos/sophos.py
+++ b/modules/antivirus/sophos/sophos.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/sophos/sophos.py
+++ b/modules/antivirus/sophos/sophos.py
@@ -81,8 +81,9 @@ class Sophos(Antivirus):
         # locate files using predefined patterns
         if self._is_windows:
             path = 'Sophos/Sophos Anti-Virus'
-            search_paths = map(lambda x: "{program_files}/{path}/*"
-                                         "".format(program_files=x, path=path),
+            search_paths = map(lambda x:
+                               "{program_files}/{path}/*"
+                               "".format(program_files=x, path=path),
                                [os.environ.get('PROGRAMFILES', ''),
                                 os.environ.get('PROGRAMFILES(X86)', '')])
         else:
@@ -106,8 +107,9 @@ class Sophos(Antivirus):
         if self._is_windows:
             path = 'Sophos/Sophos Anti-Virus'
             scan_bin = "sav32cli.exe"
-            scan_paths = map(lambda x: "{program_files}/{path}"
-                                       "".format(program_files=x, path=path),
+            scan_paths = map(lambda x:
+                             "{program_files}/{path}"
+                             "".format(program_files=x, path=path),
                              [os.environ.get('PROGRAMFILES', ''),
                               os.environ.get('PROGRAMFILES(X86)', '')])
         else:

--- a/modules/antivirus/symantec/plugin.py
+++ b/modules/antivirus/symantec/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/symantec/symantec.py
+++ b/modules/antivirus/symantec/symantec.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/virusblokada/plugin.py
+++ b/modules/antivirus/virusblokada/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/virusblokada/virusblokada.py
+++ b/modules/antivirus/virusblokada/virusblokada.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/zoner/plugin.py
+++ b/modules/antivirus/zoner/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/antivirus/zoner/zoner.py
+++ b/modules/antivirus/zoner/zoner.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/custom/skeleton/plugin.py
+++ b/modules/custom/skeleton/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/database/nsrl/nsrl.py
+++ b/modules/database/nsrl/nsrl.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/database/nsrl/plugin.py
+++ b/modules/database/nsrl/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/external/icap/plugin.py
+++ b/modules/external/icap/plugin.py
@@ -26,6 +26,7 @@ from lib.plugins import ModuleDependency, FileDependency
 from lib.plugin_result import PluginResult
 from lib.irma.common.utils import IrmaProbeType
 
+
 class ICAPPlugin(PluginBase):
 
     class ICAPResult:
@@ -62,9 +63,12 @@ class ICAPPlugin(PluginBase):
         config.read(os.path.join(os.path.dirname(__file__), 'config.ini'))
 
         self.conn_kwargs = self.retrieve_options(config, kwargs,
-                                                 (('host', str), ('port', int)))
+                                                 (('host', str),
+                                                  ('port', int)))
         self.req_kwargs = self.retrieve_options(config, kwargs,
-                                                (('service', str), ('url', str), ('timeout', int)))
+                                                (('service', str),
+                                                 ('url', str),
+                                                 ('timeout', int)))
         self.module = sys.modules['icapclient']
 
     @staticmethod
@@ -81,7 +85,7 @@ class ICAPPlugin(PluginBase):
                     pass
             if value is not None:
                 options[option] = type_(value)
-        
+
         return options
 
     def query_server(self, filename):
@@ -100,7 +104,8 @@ class ICAPPlugin(PluginBase):
                 # only read the human readable descriptions
                 threats = [s.strip() for idx, s
                            in enumerate(values[1:]) if idx % 4 == 1]
-                threat = '%s threat(s) found: %s' % (threats[0].strip(), ', '.join(threats))
+                threat = '%s threat(s) found: %s' % \
+                         (threats[0].strip(), ', '.join(threats))
             except:
                 threat = 'Multiple threats found: %s' % threat
         if threat is None:

--- a/modules/external/virustotal/plugin.py
+++ b/modules/external/virustotal/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/metadata/pe_analyzer/pe.py
+++ b/modules/metadata/pe_analyzer/pe.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/metadata/pe_analyzer/plugin.py
+++ b/modules/metadata/pe_analyzer/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/metadata/peid/plugin.py
+++ b/modules/metadata/peid/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/metadata/trid/plugin.py
+++ b/modules/metadata/trid/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/metadata/trid/trid.py
+++ b/modules/metadata/trid/trid.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/metadata/trid/trid.py
+++ b/modules/metadata/trid/trid.py
@@ -71,16 +71,16 @@ class TrID(object):
             # iterate through lines
             for line in stdout.splitlines()[4:]:
                 # find info with pattern matching
-                match = re.match(r'\s*(?P<ratio>\d*[.]\d*)[%]\s+' # percentage
-                                 r'[(](?P<ext>[.]\w*)[)]\s+' # extension
-                                 r'(?P<desc>.*)$', # remaining string
+                match = re.match(r'\s*(?P<ratio>\d*[.]\d*)[%]\s+'  # percentage
+                                 r'[(](?P<ext>[.]\w*)[)]\s+'  # extension
+                                 r'(?P<desc>.*)$',  # remaining string
                                  line)
                 # create entries to be appended to results
                 if match:
-                    entry = { 
+                    entry = {
                         'ratio': match.group('ratio'),
                         'ext':   match.group('ext'),
-                        'desc':  match.group('desc'), 
+                        'desc':  match.group('desc'),
                     }
                     results.append(entry)
         # uniformize retcode (1 is success)

--- a/modules/metadata/yara/plugin.py
+++ b/modules/metadata/yara/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/probe/tasks.py
+++ b/probe/tasks.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/copyright-update.sh
+++ b/tools/copyright-update.sh
@@ -1,0 +1,55 @@
+#!/bin/sh -e 
+#
+# Copyright (c) 2013-2015 QuarksLab.
+# This file is part of IRMA project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the top-level directory
+# of this distribution and at:
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# No part of the project, including this file, may be copied,
+# modified, propagated, or distributed except according to the
+# terms contained in the LICENSE file.
+
+
+## Setting defaults
+DROOTDIR="$PWD"
+DPATTERN="# Copyright (c) 2013-[0-9]\{4\} QuarksLab."
+DRSTRING="# Copyright (c) 2013-$(date +%Y) QuarksLab."
+
+usage() {
+    printf "\n"
+    printf "This scripts updates automatically copyright string on files that match a pattern\n"
+    printf "\n"
+    printf "usage: $0 [basedir] [pattern] [new string]\n"
+    printf "\n"
+    printf "       <basedir>    defaults to '.'\n"
+    printf "       [pattern]    defaults to 'Copyright (c) 2013-[] QuarksLab.'\n"
+    printf "       [new string] defaults to 'Copyright (c) 2013-[] QuarksLab.'\n"
+    printf "\n"
+    exit 1
+}
+
+INFO() {
+    printf "[*] $@\n"
+}
+
+if [ "$#" -eq 1 ] || [ "$#" -ge 5 ];
+then
+    usage
+fi
+
+ROOTDIR="${1:-$DROOTDIR}"
+PATTERN="${2:-$DPATTERN}"
+RSTRING="${3:-$DRSTRING}"
+
+INFO "Looking for files matching '$PATTERN' from '$ROOTDIR'.\n    Replacing with '$RSTRING'"
+
+for FILE in $(grep -Rle "$PATTERN" "$ROOTDIR");
+do
+    INFO "Pattern found in $FILE"
+    eval "sed -i 's,$PATTERN,$RSTRING,g' $FILE"
+done;

--- a/tools/nsrl/import_nsrl.py
+++ b/tools/nsrl/import_nsrl.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/run_module.py
+++ b/tools/run_module.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2014 QuarksLab.
+# Copyright (c) 2013-2015 QuarksLab.
 # This file is part of IRMA project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This commit series fixes add a ``.travis.yml`` file to check for ``pep8`` violations