### PR TITLE
sftp has been updated to allow by key authentication. New option has …

### DIFF
--- a/config/parser.py
+++ b/config/parser.py
@@ -58,6 +58,7 @@ template_probe_config = {
     'ftp_brain': [
         ('host', TemplatedConfiguration.string, None),
         ('port', TemplatedConfiguration.integer, 22),
+        ('auth', TemplatedConfiguration.string, "password"),
         ('username', TemplatedConfiguration.string, None),
         ('password', TemplatedConfiguration.string, None),
     ],

--- a/config/parser.py
+++ b/config/parser.py
@@ -22,6 +22,8 @@ from logging import BASIC_FORMAT, Formatter
 from logging.handlers import SysLogHandler
 from celery.log import redirect_stdouts_to_logger
 from celery.signals import after_setup_task_logger, after_setup_logger
+
+from lib.irma.common.exceptions import IrmaConfigurationError
 from lib.irma.configuration.ini import TemplatedConfiguration
 from lib.irma.ftp.sftp import IrmaSFTP
 from lib.irma.ftp.ftps import IrmaFTPS
@@ -59,6 +61,7 @@ template_probe_config = {
         ('host', TemplatedConfiguration.string, None),
         ('port', TemplatedConfiguration.integer, 22),
         ('auth', TemplatedConfiguration.string, "password"),
+        ('key_path', TemplatedConfiguration.string, ""),
         ('username', TemplatedConfiguration.string, None),
         ('password', TemplatedConfiguration.string, None),
     ],
@@ -204,6 +207,11 @@ def setup_debug_logger(logger):
 def get_ftp_class():
     protocol = probe_config.ftp.protocol
     if protocol == "sftp":
+        key_path = probe_config.ftp_brain.key_path
+        auth = probe_config.ftp_brain.auth
+        if auth == "key" and not os.path.isfile(key_path):
+            raise IrmaConfigurationError("You are using SFTP authentication by key but the path of the private key "
+                                         "does not exist:['" + key_path + "']")
         return IrmaSFTP
     elif protocol == "ftps":
         return IrmaFTPS

--- a/config/probe.ini
+++ b/config/probe.ini
@@ -21,6 +21,7 @@ queue = brain
 
 [ftp_brain]
 host = brain.irma
+auth = password
 username = probe
 password = probe
 

--- a/probe/controllers/ftpctrl.py
+++ b/probe/controllers/ftpctrl.py
@@ -27,6 +27,7 @@ def download_file(frontend, path, srcname, dstname):
     with IrmaFTP(ftp_config.host,
                  ftp_config.port,
                  ftp_config.auth,
+                 ftp_config.key_path,
                  ftp_config.username,
                  ftp_config.password,
                  dst_user=frontend) as ftp:

--- a/probe/controllers/ftpctrl.py
+++ b/probe/controllers/ftpctrl.py
@@ -26,6 +26,7 @@ def download_file(frontend, path, srcname, dstname):
     ftp_config = config.probe_config['ftp_brain']
     with IrmaFTP(ftp_config.host,
                  ftp_config.port,
+                 ftp_config.auth,
                  ftp_config.username,
                  ftp_config.password,
                  dst_user=frontend) as ftp:


### PR DESCRIPTION
New option is PROBE.INI configuration file:

[ftp_brain]
host = 
**auth = password || key**
username = probe
password = 

Note: To use enable key authentication in the probe:
- create a RSA key for user **irma** (~/.ssh/id_rsa)
- add the RSA public key in authorized keys of user **probe** of the brain server  (~/.ssh/authorized_keys)